### PR TITLE
Release v0.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,47 @@
+# Changelog
+
+This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+
+
+## [0.1.2] - 2020-12-20
+
+### Added
+
+- Support for ternary operators: fma (#12)
+
+### Changed
+
+- Quality Assurance:
+  - switch to GitHub Actions for CI
+
+
+
+## [0.1.1] - 2020-04-21
+
+This is the first version compatible with Julia 1.4
+
+### Added
+
+- Quality Assurance:
+  - more tests (#11)
+  - TagBot support (#7)
+  - CompatHelper support
+  
+## Changed
+
+- Update dependency compat bounds to restore compatibility with Julia 1.4 (#6, #10)
+  - Cassette (#8)
+  - BenchmarkTools (#9)
+
+
+
+## [0.1.0] - 2019-11-13
+
+Initial release
+
+### Added
+
+- Support for 32-bit and 64-bit FP formats
+- Support for binary operators: +, -, *, /
+- Support for unary operator: sqrt

--- a/Project.toml
+++ b/Project.toml
@@ -2,7 +2,7 @@ name = "GFlops"
 uuid = "2ea8233c-34d4-5acc-88b4-02f326385bcc"
 license = "MIT"
 authors = ["François Févotte <francois.fevotte@triscale-innov.com>"]
-version = "0.1.1"
+version = "0.1.2"
 
 [deps]
 BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"


### PR DESCRIPTION
## [0.1.2] - 2020-12-20

### Added

- Support for ternary operators: fma (#12)

### Changed

- Quality Assurance:
  - switch to GitHub Actions for CI