### PR TITLE
Fix @gflops issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Quality Assurance:
   - CI: finish the switch from Travis to GitHub Actions
 
+- Display memory allocs in `@gflops` output (#5)
+
+- Estimate GFlops based on the minimum time measurement provided by `@btime` (#15)
+
 
 
 ## [0.1.2] - 2020-12-20

--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ julia> x = rand(1000);
 
 julia> @count_ops sum($x)
 Flop Counter:
+ fma32: 0
+ fma64: 0
  add32: 0
  sub32: 0
  mul32: 0
@@ -33,10 +35,11 @@ Flop Counter:
  sub64: 0
  mul64: 0
  div64: 0
-
+ sqrt32: 0
+ sqrt64: 0
 
 julia> @gflops sum($x);
-  10.03 GFlops,  19.15% peak  (9.99e+02 flop, 9.96e-08 s)
+  10.03 GFlops,  19.15% peak  (9.99e+02 flop, 9.96e-08 s, 0 alloc: 0 bytes)
 ```
 
 

--- a/src/GFlops.jl
+++ b/src/GFlops.jl
@@ -1,5 +1,6 @@
 module GFlops
 import Statistics
+import BenchmarkTools
 using BenchmarkTools:   @benchmark
 using InteractiveUtils: peakflops
 using Printf:           @printf

--- a/src/count_ops.jl
+++ b/src/count_ops.jl
@@ -42,13 +42,15 @@ macro gflops(funcall)
     quote
         let
             b = @benchmark $funcall
-            ns = Statistics.mean(b.times)
+            ns = minimum(b.times)
 
             cnt = flop($(count_ops(funcall)))
             gflops = cnt/ns
             peakfraction = 1e9*gflops / peakflops()
-            @printf("  %.2f GFlops,  %.2f%% peak  (%.2e flop, %.2e s)\n",
-                    gflops, peakfraction*100,  cnt, ns*1e-9)
+            memory = $(GFlops.BenchmarkTools).prettymemory(b.memory)
+            @printf("  %.2f GFlops,  %.2f%% peak  (%.2e flop, %.2e s, %d alloc: %s)\n",
+                    gflops, peakfraction*100,  cnt, ns*1e-9,
+                    b.allocs, memory)
             gflops
         end
     end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -23,10 +23,14 @@ end
 import BenchmarkTools: @benchmark
 struct FakeResults
     times
+    allocs
+    memory
 end
 macro benchmark(e)
     quote
-        FakeResults([2.0])
+        FakeResults(#= times  =# [2.0, 3.0],
+                    #= allocs =# 1,
+                    #= memory =# 1042)
     end
 end
 


### PR DESCRIPTION
- Display memory allocs (Closes: #5)

- Estimate GFlops based on the minimum time measurement provided by  `@btime` (Closes: #15)