### PR TITLE
Pretty-print counters with PrettyTables.jl

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,10 +11,9 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Quality Assurance:
   - CI: finish the switch from Travis to GitHub Actions
   - TagBot: switch to issue comment triggers
-
 - Display memory allocs in `@gflops` output (#5)
-
 - Estimate GFlops based on the minimum time measurement provided by `@btime` (#15)
+- Flop Counters are now displayed in a pretty-printed table
 
 
 

--- a/Project.toml
+++ b/Project.toml
@@ -8,12 +8,14 @@ version = "0.1.2"
 BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"
 Cassette = "7057c7e9-c182-5462-911a-8362d720325c"
 InteractiveUtils = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
+PrettyTables = "08abe8d2-0d0c-5749-adfa-8a2ac140af0d"
 Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 
 [compat]
 BenchmarkTools = "^0.4.2, 0.5"
 Cassette = "^0.2.3, 0.3.2"
+PrettyTables = "^0.10"
 julia = "^1"
 
 [extras]

--- a/README.md
+++ b/README.md
@@ -25,18 +25,16 @@ julia> x = rand(1000);
 
 julia> @count_ops sum($x)
 Flop Counter:
- fma32: 0
- fma64: 0
- add32: 0
- sub32: 0
- mul32: 0
- div32: 0
- add64: 999
- sub64: 0
- mul64: 0
- div64: 0
- sqrt32: 0
- sqrt64: 0
+┌──────┬─────────┬─────────┐
+│      │ Float32 │ Float64 │
+├──────┼─────────┼─────────┤
+│  fma │       0 │       0 │
+│  add │       0 │     999 │
+│  sub │       0 │       0 │
+│  mul │       0 │       0 │
+│  div │       0 │       0 │
+│ sqrt │       0 │       0 │
+└──────┴─────────┴─────────┘
 
 julia> @gflops sum($x);
   10.03 GFlops,  19.15% peak  (9.99e+02 flop, 9.96e-08 s, 0 alloc: 0 bytes)
@@ -78,18 +76,16 @@ julia> x = rand(100); y = rand(100);
 # 100 FMAs...
 julia> cnt = @count_ops my_dot(x, y)
 Flop Counter:
- fma32: 0
- fma64: 100
- add32: 0
- sub32: 0
- mul32: 0
- div32: 0
- add64: 0
- sub64: 0
- mul64: 0
- div64: 0
- sqrt32: 0
- sqrt64: 0
+┌──────┬─────────┬─────────┐
+│      │ Float32 │ Float64 │
+├──────┼─────────┼─────────┤
+│  fma │       0 │     100 │
+│  add │       0 │       0 │
+│  sub │       0 │       0 │
+│  mul │       0 │       0 │
+│  div │       0 │       0 │
+│ sqrt │       0 │       0 │
+└──────┴─────────┴─────────┘
 
 # ...but 200 FLOPs
 julia> GFlops.flop(cnt)
@@ -106,14 +102,16 @@ julia> using LinearAlgebra
 
 julia> @count_ops dot($x, $x)
 Flop Counter:
- add32: 0
- sub32: 0
- mul32: 0
- div32: 0
- add64: 0
- sub64: 0
- mul64: 0
- div64: 0
+┌──────┬─────────┬─────────┐
+│      │ Float32 │ Float64 │
+├──────┼─────────┼─────────┤
+│  fma │       0 │       0 │
+│  add │       0 │       0 │
+│  sub │       0 │       0 │
+│  mul │       0 │       0 │
+│  div │       0 │       0 │
+│ sqrt │       0 │       0 │
+└──────┴─────────┴─────────┘
 ```
 
 This is a known issue; we'll try and find a way to circumvent the problem.

--- a/README.md
+++ b/README.md
@@ -16,30 +16,6 @@ the number of floating-point operations in a piece of code. When combined with
 the accuracy of `BenchmarkTools`, this allows for easy and absolute performance
 measurements.
 
-## Example use
-
-```julia
-julia> using GFlops
-
-julia> x = rand(1000);
-
-julia> @count_ops sum($x)
-Flop Counter:
-┌──────┬─────────┬─────────┐
-│      │ Float32 │ Float64 │
-├──────┼─────────┼─────────┤
-│  fma │       0 │       0 │
-│  add │       0 │     999 │
-│  sub │       0 │       0 │
-│  mul │       0 │       0 │
-│  div │       0 │       0 │
-│ sqrt │       0 │       0 │
-└──────┴─────────┴─────────┘
-
-julia> @gflops sum($x);
-  10.03 GFlops,  19.15% peak  (9.99e+02 flop, 9.96e-08 s, 0 alloc: 0 bytes)
-```
-
 
 ## Installation
 
@@ -47,6 +23,63 @@ This package is registered and can therefore be simply be installed with
 
 ```julia
 pkg> add GFlops
+```
+
+
+## Example use
+
+This simple example shows how to track the number of operations in a vector summation:
+```julia
+julia> using GFlops
+
+julia> x = rand(1000);
+
+julia> @count_ops sum($x)
+Flop Counter:
+┌─────┬─────────┐
+│     │ Float64 │
+├─────┼─────────┤
+│ add │     999 │
+└─────┴─────────┘
+
+julia> @gflops sum($x);
+  8.86 GFlops,  12.76% peak  (9.99e+02 flop, 1.13e-07 s, 0 alloc: 0 bytes)
+```
+
+<br/>
+
+`GFlops.jl` internally tracks several types of Floating-Point operations, for
+both 32-bit and 64-bit operands. Pretty-printing a Flop Counter only
+shows non-zero entries, but any individual counter can be accessed:
+```julia
+julia> function mixed_dot(x, y)
+           acc = 0.0
+           @inbounds @simd for i in eachindex(x, y)
+               acc += x[i] * y[i]
+           end
+           acc
+       end
+mixed_dot (generic function with 1 method)
+
+julia> x = rand(Float32, 1000); y = rand(Float32, 1000);
+
+julia> cnt = @count_ops mixed_dot($x, $y)
+Flop Counter:
+┌─────┬─────────┬─────────┐
+│     │ Float32 │ Float64 │
+├─────┼─────────┼─────────┤
+│ add │       0 │    1000 │
+│ mul │    1000 │       0 │
+└─────┴─────────┴─────────┘
+
+julia> fieldnames(GFlops.Counter)
+(:fma32, :fma64, :add32, :add64, :sub32, :sub64, :mul32, :mul64, :div32, :div64, :sqrt32, :sqrt64)
+
+julia> cnt.add64
+1000
+
+julia> @gflops mixed_dot($x, $y);
+  9.91 GFlops,  13.36% peak  (2.00e+03 flop, 2.02e-07 s, 0 alloc: 0 bytes)
 ```
 
 
@@ -62,34 +95,32 @@ operations for each FMA, in accordance to the way high-performance benchmarks
 usually behave:
 
 ```julia
-julia> function my_dot(x, y)
+julia> function fma_dot(x, y)
            acc = zero(eltype(x))
            @inbounds for i in eachindex(x, y)
                acc = fma(x[i], y[i], acc)
            end
            acc
        end
-my_dot (generic function with 1 method)
+fma_dot (generic function with 1 method)
 
 julia> x = rand(100); y = rand(100);
 
 # 100 FMAs...
-julia> cnt = @count_ops my_dot(x, y)
+julia> cnt = @count_ops fma_dot($x, $y)
 Flop Counter:
-┌──────┬─────────┬─────────┐
-│      │ Float32 │ Float64 │
-├──────┼─────────┼─────────┤
-│  fma │       0 │     100 │
-│  add │       0 │       0 │
-│  sub │       0 │       0 │
-│  mul │       0 │       0 │
-│  div │       0 │       0 │
-│ sqrt │       0 │       0 │
-└──────┴─────────┴─────────┘
+┌─────┬─────────┐
+│     │ Float64 │
+├─────┼─────────┤
+│ fma │     100 │
+└─────┴─────────┘
 
 # ...but 200 FLOPs
 julia> GFlops.flop(cnt)
 200
+
+julia> @gflops fma_dot($x, $y);
+  1.58 GFlops,  2.12% peak  (2.00e+02 flop, 1.27e-07 s, 0 alloc: 0 bytes)
 ```
 
 ### Non-julia code
@@ -97,21 +128,12 @@ julia> GFlops.flop(cnt)
 `GFlops.jl` does not see what happens outside the realm of Julia code. It
 especially does not see operations performed in external libraries such as BLAS
 calls:
+
 ```julia
 julia> using LinearAlgebra
 
-julia> @count_ops dot($x, $x)
-Flop Counter:
-┌──────┬─────────┬─────────┐
-│      │ Float32 │ Float64 │
-├──────┼─────────┼─────────┤
-│  fma │       0 │       0 │
-│  add │       0 │       0 │
-│  sub │       0 │       0 │
-│  mul │       0 │       0 │
-│  div │       0 │       0 │
-│ sqrt │       0 │       0 │
-└──────┴─────────┴─────────┘
+julia> @count_ops dot($x, $y)
+Flop Counter: no flop detected
 ```
 
 This is a known issue; we'll try and find a way to circumvent the problem.

--- a/examples.jl
+++ b/examples.jl
@@ -1,0 +1,42 @@
+# These examples are included in README.jl
+
+using GFlops
+x = rand(1000);
+@count_ops sum($x)
+@gflops sum($x);
+
+
+
+function mixed_dot(x, y)
+    acc = 0.0
+    @inbounds @simd for i in eachindex(x, y)
+        acc += x[i] * y[i]
+    end
+    acc
+end
+x = rand(Float32, 1000); y = rand(Float32, 1000);
+cnt = @count_ops mixed_dot($x, $y)
+fieldnames(GFlops.Counter)
+cnt.add64
+@gflops mixed_dot($x, $y);
+
+
+
+function fma_dot(x, y)
+    acc = zero(eltype(x))
+    @inbounds for i in eachindex(x, y)
+        acc = fma(x[i], y[i], acc)
+    end
+    acc
+end
+x = rand(100); y = rand(100);
+println("# 100 FMAs...")
+cnt = @count_ops fma_dot($x, $y)
+println("# ...but 200 FLOPs")
+GFlops.flop(cnt)
+@gflops fma_dot($x, $y);
+
+
+
+using LinearAlgebra
+@count_ops dot($x, $y)

--- a/src/GFlops.jl
+++ b/src/GFlops.jl
@@ -4,6 +4,7 @@ import BenchmarkTools
 using BenchmarkTools:   @benchmark
 using InteractiveUtils: peakflops
 using Printf:           @printf
+using PrettyTables:     pretty_table
 
 export @gflops, @count_ops
 

--- a/src/overdub.jl
+++ b/src/overdub.jl
@@ -85,7 +85,6 @@ end
 import Base: ==, *, show
 
 function Base.show(io::IO, c::Counter)
-    println(io, "Flop Counter:")
     type_names  = [typ    for (typ, _)    in typs]
     type_suffix = [suffix for (_, suffix) in typs]
     op_names    = [name   for (name, _)   in ops]
@@ -93,8 +92,20 @@ function Base.show(io::IO, c::Counter)
     mat = [getfield(c, Symbol(name, suffix)) for
            name   in op_names,
            suffix in type_suffix]
+
+    if flop(c) == 0
+        print(io, "Flop Counter: no flop detected")
+        return
+    end
+
+    println(io, "Flop Counter:")
+    fc(data, i) = any(data[:,i] .> 0)
+    fr(data, i) = any(data[i,:] .> 0)
     pretty_table(io, mat, type_names,
-                 row_names = op_names)
+                 row_names = op_names,
+                 filters_col = (fc,),
+                 filters_row = (fr,),
+                 newline_at_end = false)
 end
 
 function ==(c1::Counter, c2::Counter)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -35,18 +35,28 @@ macro benchmark(e)
 end
 
 
+
 @testset "GFlops" begin
     @testset "Counter" begin
-        let
-            cnt = GFlops.Counter()
-            iob = IOBuffer()
-            show(iob, cnt)
-            out = String(take!(iob))
-            @test occursin("fma",  out)
-            @test occursin("add",  out)
-            @test occursin("mul",  out)
-            @test occursin("sqrt", out)
-            @test occursin(" 0 ",  out)
+        @testset "display empty" begin
+            let
+                cnt = GFlops.Counter()
+                str = string(cnt)
+                @test str == "Flop Counter: no flop detected"
+            end
+        end
+
+        @testset "display non-empty" begin
+            let
+                cnt = GFlops.Counter()
+                cnt.add32 = 1
+                str = string(cnt)
+                @test  occursin("Float32", str)
+                @test !occursin("Float64", str)
+                @test  occursin("add",     str)
+                @test !occursin("mul",     str)
+                @test  occursin(" 1 ",     str)
+            end
         end
     end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -41,21 +41,12 @@ end
             cnt = GFlops.Counter()
             iob = IOBuffer()
             show(iob, cnt)
-            @test String(take!(iob)) == """
-Flop Counter:
- fma32: 0
- fma64: 0
- add32: 0
- sub32: 0
- mul32: 0
- div32: 0
- add64: 0
- sub64: 0
- mul64: 0
- div64: 0
- sqrt32: 0
- sqrt64: 0
-"""
+            out = String(take!(iob))
+            @test occursin("fma",  out)
+            @test occursin("add",  out)
+            @test occursin("mul",  out)
+            @test occursin("sqrt", out)
+            @test occursin(" 0 ",  out)
         end
     end
 


### PR DESCRIPTION
Use `PrettyTables.jl` to implement tabular display of Flop Counters. Unused precisions (columns) or operations (rows) are filtered out and hidden.

This should allow increasing the number of supported operations and precisions without cluttering the UI too much.

Closes: #3