### PR TITLE
Prepare for release 0.1.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 
 
-## [UNRELEASED]
+## [0.1.3] - 2020-12-23
 
 ### Changed
 
@@ -13,7 +13,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   - TagBot: switch to issue comment triggers
 - Display memory allocs in `@gflops` output (#5)
 - Estimate GFlops based on the minimum time measurement provided by `@btime` (#15)
-- Flop Counters are now displayed in a pretty-printed table
+- Flop Counters are now displayed in a pretty-printed table (#3)
 
 
 

--- a/Project.toml
+++ b/Project.toml
@@ -2,7 +2,7 @@ name = "GFlops"
 uuid = "2ea8233c-34d4-5acc-88b4-02f326385bcc"
 license = "MIT"
 authors = ["François Févotte <francois.fevotte@triscale-innov.com>"]
-version = "0.1.2"
+version = "0.1.3"
 
 [deps]
 BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"


### PR DESCRIPTION
### Changed

- Quality Assurance:
  - CI: finish the switch from Travis to GitHub Actions
  - TagBot: switch to issue comment triggers
- Display memory allocs in `@gflops` output (#5)
- Estimate GFlops based on the minimum time measurement provided by `@btime` (#15)
- Flop Counters are now displayed in a pretty-printed table (#3)
