### PR TITLE
CI tests with Julia nightly

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
         version:
           - '1.0'
           - '1'
-          #- 'nightly'
+          - 'nightly'
         os:
           - ubuntu-latest
           - macOS-latest


### PR DESCRIPTION
Now that Cassette has been fixed for Julia v1.6 & nightly, we should be able to test GFlops with the latest versions.