### PR TITLE
Compatibility with PrettyTables 0.12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 - Support for additional operations: `neg`, `abs`, `rem`, `muladd`
 
+### Changed
+
+- Fix CI issues
+- Compatibility with `CompatBounds.jl` 0.12
+
 
 
 ## [0.1.3] - 2020-12-23

--- a/Project.toml
+++ b/Project.toml
@@ -13,9 +13,9 @@ Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 
 [compat]
-BenchmarkTools = "^0.4.2, 0.5"
+BenchmarkTools = "^0.4.2, 0.5, 0.6, 0.7"
 Cassette = "^0.2.3, 0.3.2"
-PrettyTables = "^0.10"
+PrettyTables = "^0.12"
 julia = "^1"
 
 [extras]

--- a/src/Counter.jl
+++ b/src/Counter.jl
@@ -34,7 +34,8 @@ function Base.show(io::IO, c::Counter)
     print(io, "\n")
     fc(data, i) = any(data[:,i] .> 0)
     fr(data, i) = any(data[i,:] .> 0)
-    pretty_table(io, mat, type_names,
+    pretty_table(io, mat,
+                 header = type_names,
                  row_names = op_names,
                  filters_col = (fc,),
                  filters_row = (fr,),


### PR DESCRIPTION
- Use the new API of PrettyTables 0.12
- Update compat bounds for PrettyTables & BenchmarkTools
