### PR TITLE
Add Float16 support

### DIFF
--- a/src/overdub.jl
+++ b/src/overdub.jl
@@ -24,6 +24,7 @@ const unops = (
 const ops = Iterators.flatten((ternops, binops, unops)) |> collect
 
 const typs = (
+    (Float16, :16),
     (Float32, :32),
     (Float64, :64),
 )


### PR DESCRIPTION
Following #30 this also counts Float16 operations. Tested on A64FX (hardware supported Float16) and x86 (on Julia v1.6 via LLVM's half). But maybe you want to add more unit tests too?