### PR TITLE
Fix hygiene-related bug with Julia 1.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.5] - 2021-04-19
+
+This is a bugfix release.
+
+### Changed
+
+- Fix hygiene-related bug with Julia 1.6.0 (#32, #33)
+
 
 
 ## [0.1.4] - 2021-04-13
@@ -13,7 +21,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ### Changed
 
 - Fix CI issues (#22)
-- Compatibility with `CompatBounds.jl` 0.12 (#29)
+- Compatibility with `PrettyTables.jl` 0.12 (#29)
 
 
 

--- a/Project.toml
+++ b/Project.toml
@@ -2,7 +2,7 @@ name = "GFlops"
 uuid = "2ea8233c-34d4-5acc-88b4-02f326385bcc"
 license = "MIT"
 authors = ["François Févotte <francois.fevotte@triscale-innov.com>"]
-version = "0.1.4"
+version = "0.1.5"
 
 [deps]
 BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -20,21 +20,9 @@ function my_prod(m, v)
     res
 end
 
-import BenchmarkTools: @benchmark
-struct FakeResults
-    times
-    allocs
-    memory
-end
-macro benchmark(e)
-    quote
-        FakeResults(#= times  =# [2.0, 3.0],
-                    #= allocs =# 1,
-                    #= memory =# 1042)
-    end
-end
-
-
+# Fake benchmarked times
+import BenchmarkTools
+GFlops.times(::BenchmarkTools.Trial) = [2.0, 3.0]
 
 @testset "GFlops" begin
     @testset "Counter" begin
@@ -128,7 +116,7 @@ end
                 @test GFlops.flop(cnt) == 1
             end
         end
-        
+
         @testset "sqrt" begin
             let cnt = @count_ops sqrt(4.2)
                 @test cnt.sqrt64 == 1
@@ -219,15 +207,15 @@ end
             x = rand(N)
             y = Vector{Float64}(undef, N)
 
-            @test @gflops(my_axpy!(a, x, y))          == N
-            @test @gflops(my_axpy!(π, $(rand(N)), y)) == N
+            @test @gflops(my_axpy!($a, $x, $y))         == N
+            @test @gflops(my_axpy!($π, $(rand(N)), $y)) == N
         end
 
         let
             N = 100
             m = rand(N, N)
             v = rand(N)
-            @test @gflops(my_prod(m, v)) == N*N
+            @test @gflops(my_prod($m, $v)) == N*N
         end
     end
 end


### PR DESCRIPTION
It seems like Julia 1.6.0 changed something in the way hygiene is handled when a macro expands to code that uses another macro.

Hopefully this fixes #32