### PR TITLE
Remove Core.Intrinsics.rem_float for Julia 1.10

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -2,7 +2,7 @@ name = "GFlops"
 uuid = "2ea8233c-34d4-5acc-88b4-02f326385bcc"
 license = "MIT"
 authors = ["François Févotte <francois.fevotte@triscale-innov.com>"]
-version = "0.1.8"
+version = "0.1.9"
 
 [deps]
 BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"

--- a/src/overdub.jl
+++ b/src/overdub.jl
@@ -12,7 +12,7 @@ const binops = (
     (:sub, Core.Intrinsics.sub_float, 1),
     (:mul, Core.Intrinsics.mul_float, 1),
     (:div, Core.Intrinsics.div_float, 1),
-    (:rem, Core.Intrinsics.rem_float, 1),
+    (VERSION < v"1.10" ? ((:rem, Core.Intrinsics.rem_float, 1),) : () )...,
 )
 
 const unops = (


### PR DESCRIPTION
Closes #49.